### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,13 +13,13 @@ RobotDriver	KEYWORD1
 #######################################	
 
 init	KEYWORD2
-stop  KEYWORD2
-avanzar  KEYWORD2
-retroceder  KEYWORD2
+stop	KEYWORD2
+avanzar	KEYWORD2
+retroceder	KEYWORD2
 doblar_izq	KEYWORD2
 doblar_der	KEYWORD2
 mover_cabeza	KEYWORD2
-linea_negra  KEYWORD2
+linea_negra	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords